### PR TITLE
add molecule scaffolding for testing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,14 @@
+---
+on:
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          path: "${{ github.repository }}"
+      - name: molecule
+        uses: robertdebock/molecule-action@2.6.17

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,7 @@
 ---
 - name: restart sshguard
-  service:
+  systemd:
+    daemon_reload: true
     name: sshguard
     state: restarted
+  become: True

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: install ansible deps
+      apt:
+        name:
+          - virtualenv
+        state: present
+        update_cache: yes
+    - name: "Include sshguard"
+      include_role:
+        name: "sshguard_role"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: ubuntu2004
+    image: geerlingguy/docker-ubuntu2004-ansible
+    pre_build_image: True
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+  - name: ubuntu1604
+    image: geerlingguy/docker-ubuntu1604-ansible
+    pre_build_image: True
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true


### PR DESCRIPTION
Add basic scaffolding for running molecule tests that run via github actions.

We don't really have any tests, but this enables us to add them in the future.