### PR TITLE
drop 14.04 trusty support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+- drop support for Ubuntu 14.04 Trusty.
+
 ## [v1.0.1] - 2021-05-27
 
 * added missing restart handler

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,12 +18,4 @@
   systemd:
     name: sshguard.service
     enabled: true
-  when: ansible_distribution_release != 'trusty'
-  tags: ['sshguard', 'sshguard:configuration']
-
-- name: enable sshguard upstart service (trusty)
-  service:
-    name: sshguard
-    enabled: true
-  when: ansible_distribution_release == 'trusty'
   tags: ['sshguard', 'sshguard:configuration']


### PR DESCRIPTION
no reason to maintain backwards compatability that far back.